### PR TITLE
Add support for cursor on external keyboards

### DIFF
--- a/app/routes/play/components/current-word/current-word.tsx
+++ b/app/routes/play/components/current-word/current-word.tsx
@@ -2,10 +2,11 @@ import { cn } from "~/lib/utils";
 import { useGameState } from "../../hooks/use-game";
 
 export function CurrentWord() {
-  const { currentWord, message, count } = useGameState((state) => ({
+  const { currentWord, message, count, cursor } = useGameState((state) => ({
     currentWord: state.currentWord,
     message: state.message,
     count: state.count,
+    cursor: state.cursor,
   }));
 
   return (
@@ -20,7 +21,12 @@ export function CurrentWord() {
           return (
             <span
               key={index}
-              className="text-xl py-2 px-4 rounded-lg border border-dashed font-medium h-[50px] w-[50px] flex items-center justify-center transform transition-transform duration-200 hover:scale-105"
+              className={cn(
+                "text-xl py-2 px-4 rounded-lg border border-dashed font-medium h-[50px] w-[50px] flex items-center justify-center transform transition-transform duration-200 hover:scale-105",
+                {
+                  "border-indigo-300": index === cursor,
+                }
+              )}
             >
               {currentWord[index] ?? " "}
             </span>

--- a/app/routes/play/components/game-provider/game-provider.tsx
+++ b/app/routes/play/components/game-provider/game-provider.tsx
@@ -10,6 +10,7 @@ const initialState = {
   wordsOfTheDay: { start: "HELLO", target: "WORLD" },
   message: "",
   paused: false,
+  cursor: 0,
 } satisfies GameState;
 
 export const GameStateContext = createContext<GameState>(initialState);

--- a/app/routes/play/components/game-provider/game-reducer.ts
+++ b/app/routes/play/components/game-provider/game-reducer.ts
@@ -25,21 +25,26 @@ export function gameReducer(state: GameState, action: GameActions) {
     }
 
     case "key_clicked": {
-      if (action.payload === "BACK") {
+      if (action.payload === "Backspace") {
         if (state.currentWord.length === 0) {
           return state;
         }
 
+        const newCurrentWord = [...state.currentWord];
+        newCurrentWord[state.cursor] = "";
+
         return {
           ...state,
-          currentWord: state.currentWord.slice(0, state.currentWord.length - 1),
+          currentWord: newCurrentWord,
+          cursor: state.cursor <= 0 ? state.cursor : state.cursor - 1,
         } satisfies GameState;
       }
 
-      if (action.payload === "ENTER") {
+      if (action.payload === "Enter") {
         const lastEntry =
           Array.from(state.board.entries()).at(-1)?.[1] ??
           state.wordsOfTheDay.start.split("");
+
         /**
          * Validation checks
          * 1. Word is not complete
@@ -87,25 +92,43 @@ export function gameReducer(state: GameState, action: GameActions) {
         return {
           ...state,
           currentWord: [],
+          cursor: 0,
           board,
         } satisfies GameState;
+      }
+
+      if (action.payload === "ArrowLeft") {
+        return {
+          ...state,
+          cursor: state.cursor <= 0 ? state.cursor : state.cursor - 1,
+        };
+      }
+
+      if (action.payload === "ArrowRight") {
+        return {
+          ...state,
+          cursor:
+            state.cursor >= state.count - 1 ? state.cursor : state.cursor + 1,
+        };
       }
 
       if (state.paused) {
         return { ...state, message: "Game is paused. Press play to continue." };
       }
 
-      if (state.currentWord.length === state.count) {
-        return state;
-      }
+      const newCurrentWord = [...state.currentWord];
+      newCurrentWord[state.cursor] = action.payload as string;
 
       return {
         ...state,
-        currentWord: [...state.currentWord, action.payload as string],
+        currentWord: newCurrentWord,
+        cursor:
+          state.cursor >= state.count - 1 ? state.cursor : state.cursor + 1,
       } satisfies GameState;
     }
     default: {
-      throw new Error(`Unhandled action type: ${action.type}`);
+      const type: never = action satisfies never;
+      throw new Error("Unhandled action type: ", type);
     }
   }
 }

--- a/app/routes/play/components/game-provider/types.ts
+++ b/app/routes/play/components/game-provider/types.ts
@@ -8,9 +8,18 @@ export interface GameState {
   };
   message: string;
   paused: boolean;
+  cursor: number;
 }
 
-export interface GameActions {
-  type: "message" | "key_clicked" | "toggle_paused";
-  payload?: string;
+interface GameActionType {
+  message: string;
+  key_clicked: string;
+  toggle_paused: boolean;
 }
+
+export type GameActions = {
+  [K in keyof GameActionType]: {
+    type: K;
+    payload: GameActionType[K];
+  };
+}[keyof GameActionType];

--- a/app/routes/play/components/keyboard/keyboard.tsx
+++ b/app/routes/play/components/keyboard/keyboard.tsx
@@ -25,20 +25,8 @@ export function Keyboard() {
         return;
       }
 
-      const hKey =
-        e.key === "Backspace" ? "BACK" : e.key === "Enter" ? "ENTER" : e.key;
-      setHighlightedKey(hKey);
-
-      setTimeout(() => {
-        setHighlightedKey("");
-      }, 250);
-
-      if (e.key === "Backspace") {
-        return dispatch({ type: "key_clicked", payload: "BACK" });
-      }
-
-      if (e.key === "Enter") {
-        return dispatch({ type: "key_clicked", payload: "ENTER" });
+      if (["Backspace", "Enter", "ArrowLeft", "ArrowRight"].includes(e.key)) {
+        return dispatch({ type: "key_clicked", payload: e.key });
       }
 
       // For A-Z
@@ -47,6 +35,14 @@ export function Keyboard() {
       if (validKeys.has(key)) {
         dispatch({ type: "key_clicked", payload: e.key.toUpperCase() });
       }
+
+      const hKey =
+        e.key === "Backspace" ? "BACK" : e.key === "Enter" ? "ENTER" : e.key;
+      setHighlightedKey(hKey);
+
+      setTimeout(() => {
+        setHighlightedKey("");
+      }, 250);
     }
 
     document.addEventListener("keydown", handleKeyDown);


### PR DESCRIPTION
- Move cursor position on Backspace, Enter, and A-Z click (*Makes it easier to quickly edit the current word without rewriting the whole text*)
- Highlight current cursor position in current word
- Improve type narrowing (*type of action payload now gets inferred based on action type*)
- Ensure all cases are covered with new default case behaviour
